### PR TITLE
(Close #1) 100 -> 75

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Simple Bingo App.
 - CSS 3
 - ECMAScript 6
 
+## Specifications
+- The range is from 1 to 75 in default.
+- The current number appears on left side, and histories are appear on right side.
+- Just click the button to step!
+
 ## Installation
 ```bash
 git clone https://github.com/Siketyan/Bingo.git

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const count = 100;
+const count = 75;
 const getRandomInt = (min, max) => {
   min = Math.ceil(min);
   max = Math.floor(max);


### PR DESCRIPTION
Related: #1 

Bingo cards usually uses 75 numbers instead of 100 in current default.
Also this adds the specifications to README.md.